### PR TITLE
Feature/base data source header footer logic

### DIFF
--- a/SFBaseKit/SFBaseKit.podspec
+++ b/SFBaseKit/SFBaseKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SFBaseKit"
-  spec.version      = '2.0.0'
+  spec.version      = '2.1.0'
   spec.summary      = "Commonly used utilities and extensions, not-contained in native iOS frameworks."
   spec.description  = <<-DESC
   This framework includes Utils, Extensions, BaseClasses and Coordinator approach. Could be used among all projects.

--- a/SFBaseKit/SFBaseKit.xcodeproj/project.pbxproj
+++ b/SFBaseKit/SFBaseKit.xcodeproj/project.pbxproj
@@ -399,6 +399,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.upnetix.SFBaseKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -424,6 +425,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.upnetix.SFBaseKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/SFBaseKit/SFBaseKit/BaseClasses/BaseDataSourceProtocol.swift
+++ b/SFBaseKit/SFBaseKit/BaseClasses/BaseDataSourceProtocol.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-/// Protocol establishing the base data srouce properties and methods in relation with `ViewConfigurator`.
+/// Protocol establishing the base data source properties and methods in relation with `ViewConfigurator`.
 /// Usable by both `UITableView` and `UICollectionView`.
 public protocol BaseDataSource {
     
@@ -31,9 +31,9 @@ public protocol BaseDataSource {
     /// Provides the viewConfigurator for your configurable table/collection view cell
     ///
     /// - Parameter index: The index path for the current cell
-    /// - Parameter setion: The section path for the current cell
+    /// - Parameter section: The section path for the current cell
     /// - Returns: A configurator from the viewModel
-    func viewConfigurator(at index: Int, in setion: Int) -> ViewConfigurator?
+    func viewConfigurator(at index: Int, in section: Int) -> ViewConfigurator?
     
     /// Provides the viewConfigurator for your configurable header view.
     /// - Parameter section: The given section

--- a/SFBaseKit/SFBaseKit/BaseClasses/BaseDataSourceProtocol.swift
+++ b/SFBaseKit/SFBaseKit/BaseClasses/BaseDataSourceProtocol.swift
@@ -8,8 +8,14 @@
 
 import UIKit
 
+/// Protocol establishing the base data srouce properties and methods in relation with `ViewConfigurator`.
+/// Usable by both `UITableView` and `UICollectionView`.
 public protocol BaseDataSource {
     
+    /// List of reuseIdentifiers of header and footer views.
+    var headerFooterReuseIdentifiers: [String] { get }
+    
+    /// List of reuseIdentifiers of cell views.
     var reuseIdentifiers: [String] { get }
     
     /// Provides the number of sections in your table/collection view
@@ -24,12 +30,27 @@ public protocol BaseDataSource {
     
     /// Provides the viewConfigurator for your configurable table/collection view cell
     ///
-    /// - Parameter indexPath: The index path for the current cell
+    /// - Parameter index: The index path for the current cell
+    /// - Parameter setion: The section path for the current cell
     /// - Returns: A configurator from the viewModel
     func viewConfigurator(at index: Int, in setion: Int) -> ViewConfigurator?
+    
+    /// Provides the viewConfigurator for your configurable header view.
+    /// - Parameter section: The given section
+    func headerViewConfigurator(in section: Int) -> ViewConfigurator?
+    
+    /// Provides the viewConfigurator for your configurable footer view.
+    /// - Parameter section: The given section
+    func footerViewConfigurator(in section: Int) -> ViewConfigurator?
+    
 }
 
+// MARK: - BaseDataSource+Defaults
 public extension BaseDataSource {
+    
+    var headerFooterReuseIdentifiers: [String] {
+        return []
+    }
     
     var reuseIdentifiers: [String] {
         return []
@@ -40,6 +61,14 @@ public extension BaseDataSource {
     }
     
     func viewConfigurator(at index: Int, in section: Int) -> ViewConfigurator? {
+        return nil
+    }
+    
+    func headerViewConfigurator(in section: Int) -> ViewConfigurator? {
+        return nil
+    }
+    
+    func footerViewConfigurator(in section: Int) -> ViewConfigurator? {
         return nil
     }
     

--- a/SFBaseKit/SFBaseKit/BaseClasses/BaseViewConfigurator.swift
+++ b/SFBaseKit/SFBaseKit/BaseClasses/BaseViewConfigurator.swift
@@ -133,6 +133,16 @@ open class BaseViewConfigurator<ConfigurableType: Configurable>: ViewConfigurato
 
 public extension UITableView {
     
+    /// Directly register cells and headerFooterViews with `BaseDataSource` confirming instance.
+    /// - Parameter dataSource: `BaseDataSource` confirming instance, containing information for `headerFooterReuseIdentifiers` and `reuseIdentifiers`.
+    func register(with dataSource: BaseDataSource) {
+        register(headerFooterNames: dataSource.headerFooterReuseIdentifiers)
+        register(cellNames: dataSource.reuseIdentifiers)
+    }
+    
+    /// Register an array of cell names <"\(YourCellClass.self)"> to be reused
+    ///
+    /// - Parameter cellNames: The array of names
     func register(cellNames: [String]) {
         cellNames.forEach {
             register(UINib(nibName: $0, bundle: nil),
@@ -163,18 +173,28 @@ public extension UITableView {
     
     /// Register an array of header names <"\(YourHeaderClass.self)"> to be reused
     ///
-    /// - Parameter headerNames: The array of names
-    func register(headerNames: String...) {
-        for headerName in headerNames {
-            register(UINib(nibName: headerName, bundle: nil), forHeaderFooterViewReuseIdentifier: headerName)
+    /// - Parameter headerFooterNames: The array of names
+    func register(headerFooterNames: [String]) {
+        headerFooterNames.forEach {
+            register(UINib(nibName: $0, bundle: nil),
+                     forHeaderFooterViewReuseIdentifier: $0)
         }
     }
     
-    /// Called in header or footer fot section. Configures a header and returns it
+    /// Register an array of header names <"\(YourHeaderClass.self)"> to be reused
+    ///
+    /// - Parameter headerFooterNames: The array of names
+    func register(headerFooterNames: String...) {
+        for headerFooterName in headerFooterNames {
+            register(UINib(nibName: headerFooterName, bundle: nil), forHeaderFooterViewReuseIdentifier: headerFooterName)
+        }
+    }
+    
+    /// Called in header or footer for section. Configures a headerFooterView and returns it.
     ///
     /// - Parameter configurator: The configurator for the header/footer (from the viewModel)
     /// - Returns: An already configured UITableViewHeaderFooterView
-    func configureHeader(for configurator: ViewConfigurator) -> UITableViewHeaderFooterView? {
+    func configureHeaderFooter(for configurator: ViewConfigurator) -> UITableViewHeaderFooterView? {
         guard let headerFooterView = dequeueReusableHeaderFooterView(withIdentifier: configurator.reuseIdentifier) else { return nil }
         configurator.configure(headerFooterView)
         return headerFooterView

--- a/SFBaseKit/SFBaseKit/Info.plist
+++ b/SFBaseKit/SFBaseKit/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>


### PR DESCRIPTION
Base data source header footer logic BaseDataSource: Added headerFooterReuseIdentifiers; headerViewConfigurator(in section); footerViewConfigurator(in section) and documentation. extended UITableView with: register(with dataSource: BaseDataSource); func register(headerFooterNames: [String]); renamed configureHeaderFooter method.
Pod version changed from 2.0.0 to 2.1.0.